### PR TITLE
Add script to fetch and embed Latest KB articles into the vector store

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 OPENAI_API_KEY=your openai api key
 RAG_API_URL=your rag api url
+ZOHO_OAUTH_TOKEN=your_token_here
+ZOHO_ORG_ID=your_org_id_here

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ venv/
 
 # OS specific
 .DS_Store
+data_prep/latest_kb_articles.csv

--- a/data_prep/README.md
+++ b/data_prep/README.md
@@ -1,0 +1,18 @@
+# Knowledge Base Vector Prep
+
+This script fetches the latest knowledge base articles from Zoho Desk using the API and updates the local ChromaDB vector store.
+
+## What it does
+- Downloads KB articles using Zoho OAuth token
+- Normalizes and saves a clean CSV
+- Replaces the `kb_articles` collection in ChromaDB with the latest content
+
+## Usage
+1. Set your environment variables in `.env`:
+   - `ZOHO_ACCESS_TOKEN`
+   - `ZOHO_ORG_ID`
+   - `OPENAI_API_KEY`
+
+2. Run:
+   ```bash
+   python data_prep/update_kb_vectors.py

--- a/data_prep/update_kb_vectors.py
+++ b/data_prep/update_kb_vectors.py
@@ -1,0 +1,139 @@
+import os
+import requests
+import pandas as pd
+from dotenv import load_dotenv
+
+import chromadb
+from chromadb import PersistentClient 
+from chromadb.config import Settings
+from chromadb.utils import embedding_functions
+
+# Load env vars
+load_dotenv()
+
+CLIENT_ID = os.getenv("ZOHO_CLIENT_ID")
+CLIENT_SECRET = os.getenv("ZOHO_CLIENT_SECRET")
+REFRESH_TOKEN = os.getenv("ZOHO_REFRESH_TOKEN")
+ORG_ID = os.getenv("ZOHO_ORG_ID")
+CSV_OUTPUT_PATH = "latest_kb_articles.csv"
+
+# Step 1: Get new access token
+def get_access_token():
+    response = requests.post(
+        "https://accounts.zoho.com/oauth/v2/token",
+        params={
+            "refresh_token": REFRESH_TOKEN,
+            "client_id": CLIENT_ID,
+            "client_secret": CLIENT_SECRET,
+            "grant_type": "refresh_token"
+        }
+    )
+    response.raise_for_status()
+    return response.json()["access_token"]
+
+# Step 2: Fetch all paginated articles
+def fetch_all_articles():
+    token = get_access_token()
+    headers = {
+        "Authorization": f"Zoho-oauthtoken {token}",
+        "orgId": ORG_ID
+    }
+
+    base_url = "https://desk.zoho.com/api/v1/articles"
+    offset = 1  # Start at 1 (Zoho API seems to expect this)
+    limit = 50
+    all_articles = []
+
+    while True:
+        params = {
+            "from": offset,
+            "limit": limit
+        }
+        response = requests.get(base_url, headers=headers, params=params)
+
+        if response.status_code == 422:
+            print("❌ 422 error: check docs for required params or max page size.")
+            print("Response:", response.json())
+            break
+
+        response.raise_for_status()
+        data = response.json().get("data", [])
+        published_articles = [article for article in data if article.get("status") == "Published"]
+        all_articles.extend(published_articles)
+
+        print(f"✅ Fetched {len(published_articles)} published articles (offset {offset})")
+
+        if not data or len(data) < limit:
+            break  # Done paging
+
+        offset += limit
+
+    return all_articles
+
+
+
+
+
+# Step 3: Extract useful fields and save to CSV
+def save_articles_to_csv(articles):
+    rows = []
+    for article in articles:
+        rows.append({
+            "Article Id": article.get("id"),
+            "Article Title": article.get("title"),
+            "Answer": article.get("summary", ""),  # fallback to summary
+            "Status": article.get("status"),
+            "Created Time": article.get("createdTime"),
+            "Modified Time": article.get("modifiedTime"),
+            "URL": article.get("webUrl"),
+            "Topic": article.get("category", {}).get("name")
+        })
+
+    df = pd.DataFrame(rows)
+    df.to_csv(CSV_OUTPUT_PATH, index=False)
+    print(f"✅ Saved {len(df)} articles to {CSV_OUTPUT_PATH}")
+    
+# Step 4: Update ChromaDB with new embeddings
+def update_vector_store():
+    print("🔄 Updating Chroma vector store with latest KB articles...")
+
+    # Load cleaned CSV
+    df = pd.read_csv(CSV_OUTPUT_PATH).dropna(subset=["Answer"])
+
+    # Initialize Chroma PersistentClient
+    client = PersistentClient(path="chroma")  # <-- no Settings() needed here
+
+    # Drop old collection if it exists
+    if "kb_articles" in [col.name for col in client.list_collections()]:
+        client.delete_collection("kb_articles")
+
+    # Recreate collection with embedding
+    embedding_fn = embedding_functions.OpenAIEmbeddingFunction(
+        api_key=os.getenv("OPENAI_API_KEY"),
+        model_name="text-embedding-ada-002"
+    )
+    collection = client.create_collection(name="kb_articles", embedding_function=embedding_fn)
+
+    # Add articles
+    collection.add(
+        documents=df["Answer"].astype(str).tolist(),
+        ids=[str(row["Article Id"]) for _, row in df.iterrows()],
+        metadatas=[
+            {
+                "title": row["Article Title"],
+                "topic": row.get("Topic", ""),
+                "url": row.get("URL", "")
+            }
+            for _, row in df.iterrows()
+        ]
+    )
+
+    print(f"✅ Replaced kb_articles collection with {len(df)} documents.")
+
+
+
+# Run
+if __name__ == "__main__":
+    articles = fetch_all_articles()
+    save_articles_to_csv(articles)
+    update_vector_store()

--- a/prepare_rag_data.py
+++ b/prepare_rag_data.py
@@ -1,0 +1,28 @@
+import pandas as pd
+import chromadb
+from chromadb.config import Settings
+
+# Load the CSV
+df = pd.read_csv("data/rag_ready_threads.csv")
+
+# Initialize Chroma DB client (default settings for local dev)
+chroma_client = chromadb.Client(Settings(chroma_db_impl="duckdb+parquet", persist_directory="chroma"))
+
+# Create or get collection
+collection = chroma_client.get_or_create_collection(name="zoho_support_threads")
+
+# Add each document
+for idx, row in df.iterrows():
+    doc_id = str(row["ticketId"])
+    content = row["content"]
+    metadata = {
+        "createdTime_start": row["createdTime_start"],
+        "createdTime_end": row["createdTime_end"]
+    }
+    collection.add(
+        documents=[content],
+        ids=[doc_id],
+        metadatas=[metadata]
+    )
+
+print(f"✅ Loaded {len(df)} documents into Chroma collection 'zoho_support_threads'")

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ presidio-analyzer
 presidio-anonymizer
 spacy
 beautifulsoup4
+chromadb
 


### PR DESCRIPTION
This PR introduces a data pipeline script that:

- Fetches published KB articles from Zoho Desk using the API and OAuth refresh token flow
- Saves them as a clean CSV (latest_kb_articles.csv)
- Updates the kb_articles collection in ChromaDB with fresh embeddings

Also updates:

- .env.example with required Zoho credentials
- requirements.txt to include ChromaDB and dependencies