### PR TITLE
Add secure Chroma admin endpoint and thread data refresh instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,11 @@
 OPENAI_API_KEY=your openai api key
 RAG_API_URL=your rag api url
-ZOHO_OAUTH_TOKEN=your_token_here
-ZOHO_ORG_ID=your_org_id_here
+
+ZOHO_CLIENT_ID=...
+ZOHO_CLIENT_SECRET=...
+ZOHO_REFRESH_TOKEN=...
+ZOHO_ORG_ID=...
+
+ADMIN_PASSWORD=changeme
+
+

--- a/README.md
+++ b/README.md
@@ -99,3 +99,17 @@ If you prefer to develop without Docker:
 3. Embeddings are stored in a ChromaDB vector database
 4. When a query is received, it finds semantically similar content
 5. The most relevant articles are returned as responses
+
+
+## Admin Utilities
+
+### Refreshing Support Threads Collection
+
+To refresh the `support_threads` collection in Chroma with new thread data:
+
+1. Make sure the file `data/rag_ready_threads.csv` exists in the container.
+2. Call the admin endpoint with your admin password:
+
+```bash
+curl -X POST http://localhost:8000/admin/refresh-threads \
+  -H "X-Admin-Password: YOUR_ADMIN_PASSWORD"


### PR DESCRIPTION
- Adds /admin/chroma to inspect collections (password protected via X-Admin-Password)
- Adds /admin/refresh-threads to reload support threads from local CSV
- Notes in README.md about usage and security
- Deployment fallback still skips thread load if file not found